### PR TITLE
Set self.loader to first configured loader

### DIFF
--- a/pypki2/__init__.py
+++ b/pypki2/__init__.py
@@ -472,7 +472,7 @@ class _Loader(object):
             if len(configured_loaders) == 0:
                 self.loader = pick_loader(loaders)
             elif len(configured_loaders) > 0:
-                self.loader = loaders[0]
+                self.loader = configured_loaders[0]
             else:
                 raise PyPKI2Exception('No configured PKI loader available.')
 


### PR DESCRIPTION
Prior to this commit, the user is still prompted for .p12 information even if pem information is already in a user's .mypki file.